### PR TITLE
Phase 3.4: --verbose/-v フラグ実装

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ var (
 	// フラグ変数
 	flagDryRun bool
 	flagYes    bool
+	flagVerbose bool
 )
 
 // newRootCmd creates a new root command
@@ -25,9 +26,10 @@ and removes unnecessary local branches.`,
 		RunE: runCleanup,
 	}
 
-	// フラグの定義（最小限）
+	// フラグの定義
 	cmd.Flags().BoolVar(&flagDryRun, "dry-run", false, "Perform a dry run without making actual changes")
 	cmd.Flags().BoolVarP(&flagYes, "yes", "y", false, "Skip confirmation prompts")
+	cmd.Flags().BoolVarP(&flagVerbose, "verbose", "v", false, "Show detailed logs")
 
 	return cmd
 }
@@ -43,9 +45,10 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 
 	// クリーンアップオプションの設定
 	options := git.CleanupOptions{
-		DryRun: flagDryRun,
-		Yes:    flagYes,
-		NoPull: true, // 最小実装ではプルをスキップ
+		DryRun:  flagDryRun,
+		Verbose: flagVerbose,
+		Yes:     flagYes,
+		NoPull:  true, // 最小実装ではプルをスキップ
 	}
 
 	// クリーンアップ実行

--- a/internal/git/cleanup.go
+++ b/internal/git/cleanup.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"fmt"
+	"log"
 )
 
 // CleanupOptions はクリーンアップ処理のオプションを表します
@@ -34,100 +35,143 @@ func (opts *CleanupOptions) Validate() error {
 
 // ExecuteCleanup はメインのクリーンアップ処理を実行します
 func ExecuteCleanup(options CleanupOptions) (*CleanupResult, error) {
+	// verboseログ出力用のヘルパー関数
+	logVerbose := func(format string, args ...interface{}) {
+		if options.Verbose {
+			log.Printf("[VERBOSE] "+format, args...)
+		}
+	}
+
 	// オプションのバリデーション
 	if err := options.Validate(); err != nil {
 		return nil, err
 	}
+
+	logVerbose("クリーンアップ処理を開始します")
+	logVerbose("オプション: DryRun=%t, Verbose=%t, Yes=%t, Force=%t", options.DryRun, options.Verbose, options.Yes, options.Force)
 
 	result := &CleanupResult{
 		WasDryRun: options.DryRun,
 	}
 
 	// 1. Gitリポジトリかどうかの確認
+	logVerbose("Gitリポジトリの確認を開始")
 	cwd, err := GetCurrentDirectory()
 	if err != nil {
 		return nil, NewGitError("cleanup", err)
 	}
+	logVerbose("現在のディレクトリ: %s", cwd)
 
 	if err := IsGitRepository(cwd); err != nil {
 		return nil, NewGitError("cleanup", ErrNotGitRepository).WithPath(cwd)
 	}
+	logVerbose("Gitリポジトリであることを確認")
 
 	// 2. デフォルトブランチの検出
+	logVerbose("デフォルトブランチの検出を開始")
 	var defaultBranch string
 	if options.DefaultBranch != "" {
 		defaultBranch = options.DefaultBranch
+		logVerbose("手動指定されたデフォルトブランチ: %s", defaultBranch)
 	} else {
 		defaultBranch, err = DetectDefaultBranch()
 		if err != nil {
 			return nil, NewGitError("cleanup", err)
 		}
+		logVerbose("検出されたデフォルトブランチ: %s", defaultBranch)
 	}
 	result.DefaultBranch = defaultBranch
 
 	// 3. デフォルトブランチへの切り替え
+	logVerbose("現在のブランチ確認と切り替えを開始")
 	currentBranch, err := GetCurrentBranch()
 	if err != nil {
 		return nil, NewGitError("cleanup", err)
 	}
+	logVerbose("現在のブランチ: %s", currentBranch)
 
 	if currentBranch != defaultBranch {
 		if options.DryRun {
-			// ドライランモードではブランチ切り替えはシミュレーションのみ
+			logVerbose("ドライランモード: ブランチ切り替えをシミュレーション (%s -> %s)", currentBranch, defaultBranch)
 		} else {
+			logVerbose("デフォルトブランチに切り替え: %s -> %s", currentBranch, defaultBranch)
 			if err := CheckoutBranch(defaultBranch); err != nil {
 				return nil, NewGitError("cleanup", err).WithMessage("failed to switch to default branch")
 			}
+			logVerbose("ブランチ切り替え完了")
 		}
+	} else {
+		logVerbose("すでにデフォルトブランチにいます")
 	}
 
 	// 4. フェッチ処理（必須・ドライランでも実行）
+	logVerbose("フェッチ処理を開始 (git fetch --all --prune)")
 	if err := Fetch(); err != nil {
 		// フェッチ失敗は警告として扱い、処理を継続
+		logVerbose("フェッチエラー: %v", err)
 		result.Errors = append(result.Errors, NewGitError("cleanup", err).WithMessage("fetch failed"))
+	} else {
+		logVerbose("フェッチ完了")
 	}
 
 	if options.DryRun {
 		// ドライランモードの場合はfetch以外の実際の処理は行わない
+		logVerbose("ドライランモードのため、フェッチ以外の処理をスキップ")
 		return result, nil
 	}
 
 	// 5. プル処理（--no-pullが指定されていない場合）
 	if !options.NoPull {
+		logVerbose("プル処理を開始 (git pull)")
 		if err := Pull(); err != nil {
 			// プル失敗は警告として扱い、処理を継続
+			logVerbose("プルエラー: %v", err)
 			result.Errors = append(result.Errors, NewGitError("cleanup", err).WithMessage("pull failed"))
+		} else {
+			logVerbose("プル完了")
 		}
+	} else {
+		logVerbose("プル処理をスキップ (--no-pull指定)")
 	}
 
 	// 6. ローカルブランチの一覧取得
+	logVerbose("ローカルブランチ一覧を取得")
 	branches, err := ListLocalBranches()
 	if err != nil {
 		return nil, NewGitError("cleanup", err)
 	}
+	logVerbose("検出されたブランチ: %v", branches)
 
 	// 7. ブランチの削除
+	logVerbose("ブランチ削除処理を開始")
 	for _, branch := range branches {
 		if branch == defaultBranch {
 			// デフォルトブランチはスキップ
+			logVerbose("デフォルトブランチをスキップ: %s", branch)
 			result.SkippedBranches = append(result.SkippedBranches, branch)
 			continue
 		}
 
 		// 除外パターンのチェック（簡単な実装）
 		if options.ExcludePattern != "" && branch == options.ExcludePattern {
+			logVerbose("除外パターンにマッチするためスキップ: %s", branch)
 			result.SkippedBranches = append(result.SkippedBranches, branch)
 			continue
 		}
 
 		// ブランチ削除
+		logVerbose("ブランチ削除を試行: %s", branch)
 		if err := DeleteBranch(branch, options.Force); err != nil {
+			logVerbose("ブランチ削除エラー: %s - %v", branch, err)
 			result.Errors = append(result.Errors, NewGitError("cleanup", err).WithPath(branch))
 			result.SkippedBranches = append(result.SkippedBranches, branch)
 		} else {
+			logVerbose("ブランチ削除成功: %s", branch)
 			result.DeletedBranches = append(result.DeletedBranches, branch)
 		}
 	}
+
+	logVerbose("クリーンアップ処理完了 - 削除: %d, スキップ: %d, エラー: %d", len(result.DeletedBranches), len(result.SkippedBranches), len(result.Errors))
 
 	return result, nil
 }

--- a/internal/git/cleanup_verbose_test.go
+++ b/internal/git/cleanup_verbose_test.go
@@ -1,0 +1,203 @@
+package git
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+)
+
+func TestVerboseMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		options CleanupOptions
+		wantLog bool
+	}{
+		{
+			name: "verboseモード有効",
+			options: CleanupOptions{
+				DryRun:  true,
+				Verbose: true,
+				Yes:     true,
+			},
+			wantLog: true,
+		},
+		{
+			name: "verboseモード無効",
+			options: CleanupOptions{
+				DryRun:  true,
+				Verbose: false,
+				Yes:     true,
+			},
+			wantLog: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !isIntegrationTest() {
+				t.Skip("統合テスト環境でのみ実行")
+			}
+
+			// ログ出力をキャプチャ
+			var buf bytes.Buffer
+			log.SetOutput(&buf)
+			defer log.SetOutput(nil) // テスト後にリセット
+
+			// テスト用のGitリポジトリをセットアップ
+			repoPath, cleanup := createTestGitRepo(t)
+			defer cleanup()
+			restoreDir := changeDir(t, repoPath)
+			defer restoreDir()
+
+			// テスト実行
+			result, err := ExecuteCleanup(tt.options)
+			
+			// エラーは許可（リモート接続エラーなど）
+			if err != nil {
+				t.Logf("Expected error in test environment: %v", err)
+			}
+			
+			if result == nil {
+				t.Fatal("ExecuteCleanup() returned nil result")
+			}
+
+			// ログ出力の確認
+			logOutput := buf.String()
+			hasVerboseLog := strings.Contains(logOutput, "[VERBOSE]")
+
+			if tt.wantLog && !hasVerboseLog {
+				t.Errorf("verboseモードが有効なのに詳細ログが出力されていません")
+			}
+			
+			if !tt.wantLog && hasVerboseLog {
+				t.Errorf("verboseモードが無効なのに詳細ログが出力されています")
+			}
+
+			// verboseモード有効時の詳細確認
+			if tt.wantLog {
+				expectedLogs := []string{
+					"クリーンアップ処理を開始",
+					"Gitリポジトリの確認を開始",
+					"デフォルトブランチの検出を開始",
+					"フェッチ処理を開始",
+				}
+				
+				for _, expectedLog := range expectedLogs {
+					if !strings.Contains(logOutput, expectedLog) {
+						t.Errorf("期待される詳細ログが見つかりません: %s", expectedLog)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestVerboseLogContent(t *testing.T) {
+	if !isIntegrationTest() {
+		t.Skip("統合テスト環境でのみ実行")
+	}
+
+	// ログ出力をキャプチャ
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(nil)
+
+	// テスト用のGitリポジトリをセットアップ
+	repoPath, cleanup := createTestGitRepo(t)
+	defer cleanup()
+	restoreDir := changeDir(t, repoPath)
+	defer restoreDir()
+
+	options := CleanupOptions{
+		DryRun:  true,
+		Verbose: true,
+		Yes:     true,
+	}
+
+	result, err := ExecuteCleanup(options)
+	
+	// エラーは許可
+	if err != nil {
+		t.Logf("Expected error in test environment: %v", err)
+	}
+	
+	if result == nil {
+		t.Fatal("ExecuteCleanup() returned nil result")
+	}
+
+	logOutput := buf.String()
+	
+	// オプション情報がログに含まれているか確認
+	if !strings.Contains(logOutput, "DryRun=true") {
+		t.Error("オプション情報がログに含まれていません")
+	}
+	
+	if !strings.Contains(logOutput, "Verbose=true") {
+		t.Error("verboseオプション情報がログに含まれていません")
+	}
+
+	// 処理ステップがログに含まれているか確認
+	expectedSteps := []string{
+		"現在のディレクトリ:",
+		"検出されたデフォルトブランチ:",
+		"現在のブランチ:",
+		"git fetch --all --prune",
+		"ドライランモードのため",
+	}
+	
+	for _, step := range expectedSteps {
+		if !strings.Contains(logOutput, step) {
+			t.Errorf("期待される処理ステップがログに含まれていません: %s", step)
+		}
+	}
+}
+
+func TestVerboseWithNormalMode(t *testing.T) {
+	// verboseフラグが通常の動作に影響しないことを確認
+	if !isIntegrationTest() {
+		t.Skip("統合テスト環境でのみ実行")
+	}
+
+	repoPath, cleanup := createTestGitRepo(t)
+	defer cleanup()
+	restoreDir := changeDir(t, repoPath)
+	defer restoreDir()
+
+	// verbose無効での実行
+	options1 := CleanupOptions{
+		DryRun:  true,
+		Verbose: false,
+		Yes:     true,
+	}
+
+	result1, err1 := ExecuteCleanup(options1)
+
+	// verbose有効での実行（ログ出力をキャプチャ）
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(nil)
+
+	options2 := CleanupOptions{
+		DryRun:  true,
+		Verbose: true,
+		Yes:     true,
+	}
+
+	result2, err2 := ExecuteCleanup(options2)
+
+	// 結果が同じであることを確認（ログ出力以外）
+	if (err1 == nil) != (err2 == nil) {
+		t.Error("verboseモードの有無でエラー状態が異なります")
+	}
+
+	if result1 != nil && result2 != nil {
+		if result1.DefaultBranch != result2.DefaultBranch {
+			t.Error("verboseモードの有無でDefaultBranchが異なります")
+		}
+		
+		if result1.WasDryRun != result2.WasDryRun {
+			t.Error("verboseモードの有無でWasDryRunが異なります")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
詳細ログ出力機能（`--verbose/-v`）を実装し、gitcの実行過程を詳細に確認できるようになりました

## 実装内容

### ✅ 新機能
- **`--verbose/-v` フラグ**: 詳細ログ出力の有効/無効制御
- **詳細ログ機能**: クリーンアップ処理の各ステップでログ出力

### 🔧 技術的詳細
- `CleanupOptions.Verbose` フィールド追加
- 各処理ステップでの詳細ログ出力
- ログフォーマット: `[VERBOSE] メッセージ`

### 📋 出力される詳細情報
- オプション設定値
- 現在のディレクトリ・ブランチ状態
- デフォルトブランチ検出結果
- フェッチ・プル処理の開始/完了
- ブランチ削除の詳細（成功/失敗）
- 処理結果サマリー

### 🧪 テスト
- `TestVerboseMode`: フラグの有効/無効確認
- `TestVerboseLogContent`: ログ内容の詳細確認
- `TestVerboseWithNormalMode`: 通常モードへの影響なし確認
- 既存テスト全てパス

## 使用例
```bash
# 通常実行（ログなし）
./gitc --dry-run

# 詳細ログ付き実行
./gitc --dry-run --verbose
./gitc -v --yes
```

デバッグやトラブルシューティングに有用な機能追加