### PR TITLE
Phase 3.4: --default-branch オプション実装

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,8 +10,9 @@ import (
 
 var (
 	// フラグ変数
-	flagDryRun bool
-	flagYes    bool
+	flagDryRun        bool
+	flagYes           bool
+	flagDefaultBranch string
 )
 
 // newRootCmd creates a new root command
@@ -25,9 +26,10 @@ and removes unnecessary local branches.`,
 		RunE: runCleanup,
 	}
 
-	// フラグの定義（最小限）
+	// フラグの定義
 	cmd.Flags().BoolVar(&flagDryRun, "dry-run", false, "Perform a dry run without making actual changes")
 	cmd.Flags().BoolVarP(&flagYes, "yes", "y", false, "Skip confirmation prompts")
+	cmd.Flags().StringVar(&flagDefaultBranch, "default-branch", "", "Specify the default branch to switch to")
 
 	return cmd
 }
@@ -43,9 +45,10 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 
 	// クリーンアップオプションの設定
 	options := git.CleanupOptions{
-		DryRun: flagDryRun,
-		Yes:    flagYes,
-		NoPull: true, // 最小実装ではプルをスキップ
+		DryRun:        flagDryRun,
+		Yes:           flagYes,
+		DefaultBranch: flagDefaultBranch,
+		NoPull:        true, // 最小実装ではプルをスキップ
 	}
 
 	// クリーンアップ実行

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -114,6 +114,37 @@ func DeleteBranch(branch string, force bool) error {
 	return nil
 }
 
+// BranchExists は指定されたブランチが存在するかチェックします
+func BranchExists(branch string) (bool, error) {
+	// ローカルブランチをチェック
+	localBranches, err := ListLocalBranches()
+	if err != nil {
+		return false, NewGitError("check-branch-exists", err).WithMessage("failed to list local branches")
+	}
+
+	for _, localBranch := range localBranches {
+		if localBranch == branch {
+			return true, nil
+		}
+	}
+
+	// リモートブランチもチェック
+	remoteBranches, err := ListRemoteBranches()
+	if err != nil {
+		// リモートブランチの取得に失敗した場合は警告として扱い、ローカルのみの結果を返す
+		return false, nil
+	}
+
+	for _, remoteBranch := range remoteBranches {
+		// origin/branch 形式のリモートブランチ名から branch 部分を抽出
+		if strings.HasSuffix(remoteBranch, "/"+branch) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 // filterEmptyStrings はスライスから空文字列を除去します
 func filterEmptyStrings(strs []string) []string {
 	var filtered []string

--- a/internal/git/branch_default_test.go
+++ b/internal/git/branch_default_test.go
@@ -1,0 +1,198 @@
+package git
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestBranchExists(t *testing.T) {
+	if !isIntegrationTest() {
+		t.Skip("統合テスト環境でのみ実行")
+	}
+
+	// テスト用のGitリポジトリをセットアップ
+	repoPath, cleanup := createTestGitRepo(t)
+	defer cleanup()
+	restoreDir := changeDir(t, repoPath)
+	defer restoreDir()
+
+	// テスト用ブランチを作成
+	cmd := exec.Command("git", "checkout", "-b", "test-branch")
+	cmd.Dir = repoPath
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to create test branch: %v", err)
+	}
+
+	// mainブランチに戻る
+	cmd = exec.Command("git", "checkout", "main")
+	cmd.Dir = repoPath
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to checkout main: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		branch     string
+		wantExists bool
+		wantError  bool
+	}{
+		{
+			name:       "存在するブランチ（main）",
+			branch:     "main",
+			wantExists: true,
+			wantError:  false,
+		},
+		{
+			name:       "存在するブランチ（test-branch）",
+			branch:     "test-branch",
+			wantExists: true,
+			wantError:  false,
+		},
+		{
+			name:       "存在しないブランチ",
+			branch:     "non-existent-branch",
+			wantExists: false,
+			wantError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exists, err := BranchExists(tt.branch)
+
+			if tt.wantError && err == nil {
+				t.Errorf("BranchExists() expected error but got none")
+			}
+			if !tt.wantError && err != nil {
+				t.Errorf("BranchExists() unexpected error: %v", err)
+			}
+			if exists != tt.wantExists {
+				t.Errorf("BranchExists() = %v, want %v", exists, tt.wantExists)
+			}
+		})
+	}
+}
+
+func TestDefaultBranchOption(t *testing.T) {
+	if !isIntegrationTest() {
+		t.Skip("統合テスト環境でのみ実行")
+	}
+
+	// テスト用のGitリポジトリをセットアップ
+	repoPath, cleanup := createTestGitRepo(t)
+	defer cleanup()
+	restoreDir := changeDir(t, repoPath)
+	defer restoreDir()
+
+	// テスト用ブランチを作成
+	cmd := exec.Command("git", "checkout", "-b", "custom-default")
+	cmd.Dir = repoPath
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to create custom-default branch: %v", err)
+	}
+
+	// mainブランチに戻る
+	cmd = exec.Command("git", "checkout", "main")
+	cmd.Dir = repoPath
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to checkout main: %v", err)
+	}
+
+	tests := []struct {
+		name            string
+		defaultBranch   string
+		wantError       bool
+		expectedBranch  string
+	}{
+		{
+			name:            "存在するカスタムブランチを指定",
+			defaultBranch:   "custom-default",
+			wantError:       false,
+			expectedBranch:  "custom-default",
+		},
+		{
+			name:            "存在しないブランチを指定",
+			defaultBranch:   "non-existent",
+			wantError:       true,
+			expectedBranch:  "",
+		},
+		{
+			name:            "空文字列（自動検出）",
+			defaultBranch:   "",
+			wantError:       false,
+			expectedBranch:  "main", // 自動検出でmainが選ばれる
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := CleanupOptions{
+				DryRun:        true, // ドライランで安全にテスト
+				DefaultBranch: tt.defaultBranch,
+				Yes:           true,
+			}
+
+			result, err := ExecuteCleanup(options)
+
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("ExecuteCleanup() expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("ExecuteCleanup() unexpected error: %v", err)
+				return
+			}
+
+			if result == nil {
+				t.Fatal("ExecuteCleanup() returned nil result")
+			}
+
+			if result.DefaultBranch != tt.expectedBranch {
+				t.Errorf("ExecuteCleanup() DefaultBranch = %v, want %v", result.DefaultBranch, tt.expectedBranch)
+			}
+		})
+	}
+}
+
+func TestDefaultBranchValidation(t *testing.T) {
+	if !isIntegrationTest() {
+		t.Skip("統合テスト環境でのみ実行")
+	}
+
+	// テスト用のGitリポジトリをセットアップ
+	repoPath, cleanup := createTestGitRepo(t)
+	defer cleanup()
+	restoreDir := changeDir(t, repoPath)
+	defer restoreDir()
+
+	// 存在しないブランチでのテスト
+	options := CleanupOptions{
+		DryRun:        true,
+		DefaultBranch: "definitely-does-not-exist",
+		Yes:           true,
+	}
+
+	_, err := ExecuteCleanup(options)
+	if err == nil {
+		t.Error("ExecuteCleanup() should fail with non-existent branch")
+	}
+
+	// エラーメッセージに指定したブランチ名が含まれているか確認
+	errorStr := err.Error()
+	if !containsBranchName(errorStr, "definitely-does-not-exist") {
+		t.Errorf("Error message should contain branch name: %s", errorStr)
+	}
+}
+
+// containsBranchName はテスト用のヘルパー関数
+func containsBranchName(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/git/cleanup.go
+++ b/internal/git/cleanup.go
@@ -56,6 +56,14 @@ func ExecuteCleanup(options CleanupOptions) (*CleanupResult, error) {
 	// 2. デフォルトブランチの検出
 	var defaultBranch string
 	if options.DefaultBranch != "" {
+		// 手動指定されたブランチの存在確認
+		exists, err := BranchExists(options.DefaultBranch)
+		if err != nil {
+			return nil, NewGitError("cleanup", err).WithMessage("failed to check branch existence")
+		}
+		if !exists {
+			return nil, NewGitError("cleanup", fmt.Errorf("specified branch '%s' does not exist", options.DefaultBranch))
+		}
 		defaultBranch = options.DefaultBranch
 	} else {
 		defaultBranch, err = DetectDefaultBranch()


### PR DESCRIPTION
## Summary
ユーザーが任意のデフォルトブランチを指定できる`--default-branch`オプションを実装

## 実装内容

### ✅ 新機能
- **`--default-branch <branch>` フラグ**: 手動でデフォルトブランチを指定
- **ブランチ存在確認**: 指定されたブランチの存在を事前チェック
- **適切なエラーハンドリング**: 存在しないブランチ指定時の明確なエラーメッセージ

### 🔧 技術的詳細
- `BranchExists()` 関数追加: ローカル・リモートブランチの存在確認
- `CleanupOptions.DefaultBranch` フィールド活用
- ブランチ指定時の事前バリデーション

### 📋 動作仕様
1. **自動検出モード** (従来): `--default-branch` 未指定時
2. **手動指定モード** (新機能): `--default-branch <branch>` 指定時
   - ブランチ存在確認
   - 存在しない場合はエラーで終了

### 🧪 テスト
- `TestBranchExists`: ブランチ存在確認機能
- `TestDefaultBranchOption`: オプション指定の正常系・異常系
- `TestDefaultBranchValidation`: バリデーション機能
- 既存テスト全てパス

## 使用例
```bash
# 自動検出（従来通り）
./gitc --dry-run

# 手動指定
./gitc --dry-run --default-branch develop
./gitc --default-branch main --yes

# 存在しないブランチ指定（エラー）
./gitc --default-branch non-existent
# Error: specified branch 'non-existent' does not exist
```

ユーザーの柔軟性を向上させる便利機能の追加